### PR TITLE
Now the full test set should pass

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -2,4 +2,4 @@
 set -e
 
 export QT_QPA_PLATFORM=offscreen
-pytest --pyargs badger -k 'not cli_main and not cli_run'
+pytest --pyargs badger


### PR DESCRIPTION
Badger v0.5.3 is available on conda so I changed the test command back to do the full test.