### PR TITLE
Fix a qt version related issue

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - xopt
   - bayesian-optimization
   - pyepics
+  - qt=5.12.5
   - badger-opt=0.6.0
   - pytest
   - pytest-qt


### PR DESCRIPTION
Now we'll use pyqt 5.12.3 by default (was 5.9.2).